### PR TITLE
Allow inline markdown in notification body messages

### DIFF
--- a/src/Livewire/ToggleMaintenance.php
+++ b/src/Livewire/ToggleMaintenance.php
@@ -47,14 +47,15 @@ class ToggleMaintenance extends Component
 
 		$this->isDown = app()->isDownForMaintenance();
 
+		$notificationBody = $this->isDown
+			? __('maintenance-switch::general.success.body.down', ['secret' => $this->secret])
+			: __('maintenance-switch::general.success.body.up');
+
 		Notification::make()
 			->title(__('maintenance-switch::general.success.title', [
 				'status' => $this->isDown ? __('maintenance-switch::general.activated') : __('maintenance-switch::general.deactivated'),
 			]))
-			->body($this->isDown
-				? __('maintenance-switch::general.success.body.down', ['secret' => $this->secret])
-				: __('maintenance-switch::general.success.body.up')
-			)
+			->body(Str::inlineMarkdown($notificationBody))
 			->seconds($this->isDown ? 12 : 6)
 			->success()
 			->send();


### PR DESCRIPTION
This PR fixes raw markdown showing in the down message.

By default, Filament doesn't render markdown. By adding `Str::inlineMarkdown` it allows inline elements such as `<strong>` and `<em>` to render while also not being sanitised by Laravel's `Str::sanitizeHtml` method.

Before:
![image](https://github.com/Keysaw/maintenance-switch/assets/46111684/7a78e80e-ff3c-4215-acc5-0231f41662f5)

After:
![image](https://github.com/Keysaw/maintenance-switch/assets/46111684/2dabf7c3-5fd0-42d0-8dbd-99abad2e956f)

Thanks for making this package!
