### PR TITLE
improve redirection with intendedUrl

### DIFF
--- a/src/Livewire/ToggleMaintenance.php
+++ b/src/Livewire/ToggleMaintenance.php
@@ -60,7 +60,9 @@ class ToggleMaintenance extends Component
 			->success()
 			->send();
 
-		return $this->isDown ? redirect($this->secret) : null;
+		return $this->isDown ?
+			redirect()->setIntendedUrl(url()->previousPath())->to($this->secret) :
+			null;
 	}
 
 	public function render() : View


### PR DESCRIPTION
Following this Laravel PR: https://github.com/laravel/framework/pull/56514/files, when accessing the system using a secret during maintenance mode, it's now possible to set a redirect path after validation.
This uses the same mechanism Laravel uses for login redirection, as shown here:
https://github.com/laravel/framework/blob/767f9b71918c2b33c64fcb507e7947b76be53165/src/Illuminate/Routing/Redirector.php#L80